### PR TITLE
Modified scripts to be agnostic to input variantID format

### DIFF
--- a/src/afcn.py
+++ b/src/afcn.py
@@ -207,7 +207,7 @@ def main():
 
     #Save results
     print("Writing results to file: " + str(args.output)) 
-    out_df.to_csv(args.output, index=None)
+    out_df.to_csv(args.output, index=None, sep='\t')
     
 
      

--- a/src/afcn.py
+++ b/src/afcn.py
@@ -168,11 +168,11 @@ def main():
 
         thisgene_expressions = expression_matrix[expression_matrix.index.isin([gene])]
         #variants in this gene
-        thisgene_variants = eqtl_matrix[eqtl_matrix.gene_id_clean == gene].variant_id
+        thisgene_variants = eqtl_matrix[eqtl_matrix.gene_id_clean == gene].variant_id_clean
         #haplotypes for these variants for all inds
         thisgene_haplotypes = haplotype_matrix[haplotype_matrix.index.isin(list(thisgene_variants))]
         #the eqtl entries for this gene
-        thisgene_eqtls = eqtl_matrix[(eqtl_matrix.gene_id_clean == gene) & (eqtl_matrix.variant_id.isin(list(thisgene_variants)))]    
+        thisgene_eqtls = eqtl_matrix[(eqtl_matrix.gene_id_clean == gene) & (eqtl_matrix.variant_id_clean.isin(list(thisgene_variants)))]    
         #save in dictionary
         inputs[gene] = [thisgene_expressions, thisgene_eqtls, thisgene_haplotypes, cov_dataf_full, args]
 
@@ -192,7 +192,7 @@ def main():
     out_df = pd.merge(eqtl_dataframe_copy, final_df, how='left',on=original_columns )
 
     #now drop the gene_id_clean column
-    out_df = out_df.drop(columns=["gene_id_clean"])
+    out_df = out_df.drop(columns=["gene_id_clean", "variant_id_clean"])
     
     ###############################################################################
     #

--- a/src/calc.pyx
+++ b/src/calc.pyx
@@ -312,17 +312,17 @@ def nocovar_least_squares(h1, h2, thisgene_expressions, eqtl_dataf, sa, c0, args
         if parameter in variant_list:
             
        
-            eqtl_dataf.log2_aFC[(parameter == eqtl_dataf.variant_id) & (eqtl_dataf.gene_id_clean == gene)] = result.params[parameter].value
-            eqtl_dataf.log2_aFC_error[(parameter == eqtl_dataf.variant_id) & (eqtl_dataf.gene_id_clean == gene)] = result.params[parameter].stderr
+            eqtl_dataf.log2_aFC[(parameter == eqtl_dataf.variant_id_clean) & (eqtl_dataf.gene_id_clean == gene)] = result.params[parameter].value
+            eqtl_dataf.log2_aFC_error[(parameter == eqtl_dataf.variant_id_clean) & (eqtl_dataf.gene_id_clean == gene)] = result.params[parameter].stderr
        
             if ci_unsuccessful == 0:
        
                 #get +-95% intervals
                 minus_95 = ci[parameter][1][1]
-                eqtl_dataf.log2_aFC_min_95_interv[(parameter == eqtl_dataf.variant_id) & (eqtl_dataf.gene_id_clean == gene)] = minus_95
+                eqtl_dataf.log2_aFC_min_95_interv[(parameter == eqtl_dataf.variant_id_clean) & (eqtl_dataf.gene_id_clean == gene)] = minus_95
        
                 plus_95 = ci[parameter][5][1]
-                eqtl_dataf.log2_aFC_plus_95_interv[(parameter == eqtl_dataf.variant_id) & (eqtl_dataf.gene_id_clean == gene)] = plus_95
+                eqtl_dataf.log2_aFC_plus_95_interv[(parameter == eqtl_dataf.variant_id_clean) & (eqtl_dataf.gene_id_clean == gene)] = plus_95
        
        
         else: #its C0
@@ -344,7 +344,7 @@ def nocovar_least_squares(h1, h2, thisgene_expressions, eqtl_dataf, sa, c0, args
     for lowq_eqtl in zero_list.keys():
  
         # No need for confidence intervals
-        eqtl_dataf.log2_aFC[( lowq_eqtl == eqtl_dataf.variant_id) & (eqtl_dataf.gene_id_clean == gene)] = 0
+        eqtl_dataf.log2_aFC[( lowq_eqtl == eqtl_dataf.variant_id_clean) & (eqtl_dataf.gene_id_clean == gene)] = 0
 
     return eqtl_dataf
 
@@ -403,17 +403,17 @@ def least_squares(h1, h2, thisgene_expressions, eqtl_dataf, covar, args):
         #if parameter is an s value, variant_order excludes variants with nan values
         if parameter in variant_list:
 
-            eqtl_dataf.log2_aFC[(parameter == eqtl_dataf.variant_id) & (eqtl_dataf.gene_id_clean == gene)] = result.params[parameter].value
-            eqtl_dataf.log2_aFC_error[(parameter == eqtl_dataf.variant_id) & (eqtl_dataf.gene_id_clean == gene)] = result.params[parameter].stderr
+            eqtl_dataf.log2_aFC[(parameter == eqtl_dataf.variant_id_clean) & (eqtl_dataf.gene_id_clean == gene)] = result.params[parameter].value
+            eqtl_dataf.log2_aFC_error[(parameter == eqtl_dataf.variant_id_clean) & (eqtl_dataf.gene_id_clean == gene)] = result.params[parameter].stderr
 
             if ci_unsuccessful == 0:
 
                 #get +-95% intervals
                 minus_95 = ci[parameter][1][1]
-                eqtl_dataf.log2_aFC_min_95_interv[(parameter == eqtl_dataf.variant_id) & (eqtl_dataf.gene_id_clean == gene)] = minus_95
+                eqtl_dataf.log2_aFC_min_95_interv[(parameter == eqtl_dataf.variant_id_clean) & (eqtl_dataf.gene_id_clean == gene)] = minus_95
 
                 plus_95 = ci[parameter][5][1]
-                eqtl_dataf.log2_aFC_plus_95_interv[(parameter == eqtl_dataf.variant_id) & (eqtl_dataf.gene_id_clean == gene)] = plus_95
+                eqtl_dataf.log2_aFC_plus_95_interv[(parameter == eqtl_dataf.variant_id_clean) & (eqtl_dataf.gene_id_clean == gene)] = plus_95
 
 
         else: #its C0 or one of the peer factors

--- a/src/parse.pyx
+++ b/src/parse.pyx
@@ -8,23 +8,6 @@ import warnings
 import sys
 warnings.filterwarnings("ignore")
 
-def is_variant_id_format_valid(eqtl_file):
-
-    '''Checks if the variant ids in the eqtl matrix begin with a valid character'''
-
-    #get the first character of all rows
-    variant_ids = eqtl_file['variant_id'].tolist()
-    firstchar_isdigit = [str(var_id)[0].isalpha() for var_id in variant_ids]
-
-    #check if any of these characters is a digit
-    if True in firstchar_isdigit:
-
-        return True
-
-    else:
-
-        return False
-
 
 def read_eqtls(eqtl_filename):
     


### PR DESCRIPTION
As is, the tool requires that variants IDs (both in the input `--eqtl` file, and `--vcf` file) be formatted `<chrom>_<pos>...`. As far as I can tell, there are two reasons for this:
1. It allows the program to parse the variant's position from its ID.
2. It meets the formatting requirements used by `lmfit` in the fitting step.

I am proposing changes that make the tool agnostic to the format of the variant IDs (I can imagine some users have VCFs that use dbSNP rsIDs, for example). Briefly, the changes are as follows:
1. the `--eqtl` file now must include two additional columns: `variant_chr` and `variant_pos` that describe the (1-based) position of each variant. This information is then used to fetch the genotypes from the tabix-indexed VCF
2. Variants are assigned unique temporary IDs (a new `variant_id_clean` column) that meet the formatting requirements of `lmfit` and are used when fitting the model.
3. I've also updated the `gene_id_clean` functionality to match that of the new `variant_id_clean` column. This assumes no specific formatting of the input gene IDs.